### PR TITLE
Add Jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "nodemon --ext ts src/server.ts"
   },
   "keywords": [],

--- a/tests/clienteService.test.ts
+++ b/tests/clienteService.test.ts
@@ -1,0 +1,30 @@
+import * as ClienteModel from '../src/models/Cliente';
+import { registrarCliente, obtenerClientes } from '../src/services/clienteService';
+
+jest.mock('../src/models/Cliente');
+
+describe('clienteService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('obtenerClientes debe invocar getAllClientes', async () => {
+    (ClienteModel.getAllClientes as jest.Mock).mockResolvedValue([]);
+    await obtenerClientes();
+    expect(ClienteModel.getAllClientes).toHaveBeenCalled();
+  });
+
+  it('registrarCliente debe crear y devolver los datos del cliente', async () => {
+    (ClienteModel.createCliente as jest.Mock).mockResolvedValue(1);
+    const resultado = await registrarCliente('Emp', 'Contacto', '123', '456', 'c@e.com');
+    expect(ClienteModel.createCliente).toHaveBeenCalledWith('Emp', 'Contacto', '123', '456', 'c@e.com');
+    expect(resultado).toEqual({
+      id: 1,
+      nombre_empresa: 'Emp',
+      nombre_contacto: 'Contacto',
+      telefono_fijo: '123',
+      celular: '456',
+      email: 'c@e.com'
+    });
+  });
+});

--- a/tests/construccionService.test.ts
+++ b/tests/construccionService.test.ts
@@ -1,0 +1,60 @@
+import * as ConstruccionModel from '../src/models/Construccion';
+import {
+  obtenerConstrucciones,
+  obteneConstruccionById,
+  registrarConstruccion,
+  editarConstruccion,
+  eliminarConstruccion,
+  buscarConstrucciones
+} from '../src/services/construccionService';
+
+jest.mock('../src/models/Construccion');
+
+describe('construccionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('obtenerConstrucciones debe invocar getAllConstrucciones', async () => {
+    (ConstruccionModel.getAllConstrucciones as jest.Mock).mockResolvedValue([]);
+    await obtenerConstrucciones();
+    expect(ConstruccionModel.getAllConstrucciones).toHaveBeenCalled();
+  });
+
+  it('obteneConstruccionById debe invocar getConstruccionById y devolver los datos', async () => {
+    (ConstruccionModel.getConstruccionById as jest.Mock).mockResolvedValue({id:1});
+    const res = await obteneConstruccionById(1);
+    expect(ConstruccionModel.getConstruccionById).toHaveBeenCalledWith(1);
+    expect(res).toEqual({id:1});
+  });
+
+  it('registrarConstruccion debe crear y devolver los datos', async () => {
+    (ConstruccionModel.createConstruccion as jest.Mock).mockResolvedValue(5);
+    const res = await registrarConstruccion(2,'dir','est','cont','cel');
+    expect(ConstruccionModel.createConstruccion).toHaveBeenCalledWith(2,'dir','est','cont','cel');
+    expect(res).toEqual({
+      id_cliente:2,
+      direccion:'dir',
+      estado_obra:'est',
+      nombre_contacto_obra:'cont',
+      celular_contacto_obra:'cel'
+    });
+  });
+
+  it('editarConstruccion debe invocar updateConstruccion', async () => {
+    await editarConstruccion(3,'d','e','c','c2');
+    expect(ConstruccionModel.updateConstruccion).toHaveBeenCalledWith(3,'d','e','c','c2');
+  });
+
+  it('eliminarConstruccion debe invocar deleteConstruccion', async () => {
+    await eliminarConstruccion(4);
+    expect(ConstruccionModel.deleteConstruccion).toHaveBeenCalledWith(4);
+  });
+
+  it('buscarConstrucciones debe invocar buscarConstrucciones con filtros', async () => {
+    const filtros = {cliente:'c', direccion:'d', estado:'e'};
+    (ConstruccionModel.buscarConstrucciones as jest.Mock).mockResolvedValue([]);
+    await buscarConstrucciones(filtros);
+    expect(ConstruccionModel.buscarConstrucciones).toHaveBeenCalledWith(filtros);
+  });
+});

--- a/tests/logService.test.ts
+++ b/tests/logService.test.ts
@@ -1,0 +1,26 @@
+import pool from '../src/config/db';
+import { crearLog, obtenerLogsRecientes } from '../src/services/logService';
+
+jest.mock('../src/config/db', () => ({
+  __esModule: true,
+  default: { query: jest.fn() }
+}));
+
+describe('logService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('crearLog debe insertar el log', async () => {
+    await crearLog({ id_usuario: 1, accion: 'ACC', detalle: 'DET' });
+    expect(pool.query).toHaveBeenCalledWith(
+      'INSERT INTO logs (id_usuario, accion, detalle) VALUES (?, ?, ?)',
+      [1, 'ACC', 'DET']
+    );
+  });
+
+  it('obtenerLogsRecientes debe retornar filas', async () => {
+    (pool.query as jest.Mock).mockResolvedValue([{ id: 1 }]);
+    const rows = await obtenerLogsRecientes();
+    expect(pool.query).toHaveBeenCalled();
+    expect(rows).toEqual([{ id: 1 }]);
+  });
+});

--- a/tests/metricasService.test.ts
+++ b/tests/metricasService.test.ts
@@ -1,0 +1,106 @@
+import * as MetricasModel from '../src/models/Metricas';
+import * as service from '../src/services/metricasService';
+
+jest.mock('../src/models/Metricas');
+
+describe('metricasService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('getProductosMasVendidos', async () => {
+    (MetricasModel.obtenerProductosMasVendidos as jest.Mock).mockResolvedValue([1]);
+    const res = await service.getProductosMasVendidos();
+    expect(MetricasModel.obtenerProductosMasVendidos).toHaveBeenCalled();
+    expect(res).toEqual([1]);
+  });
+
+  it('getIngresosMensuales', async () => {
+    (MetricasModel.obtenerIngresosMensuales as jest.Mock).mockResolvedValue([2]);
+    const res = await service.getIngresosMensuales();
+    expect(MetricasModel.obtenerIngresosMensuales).toHaveBeenCalled();
+    expect(res).toEqual([2]);
+  });
+
+  it('getPromedioDescuento', async () => {
+    (MetricasModel.obtenerPromedioDescuento as jest.Mock).mockResolvedValue([3]);
+    const res = await service.getPromedioDescuento();
+    expect(MetricasModel.obtenerPromedioDescuento).toHaveBeenCalled();
+    expect(res).toEqual([3]);
+  });
+
+  it('obtenerPerdidasPorOrden', async () => {
+    (MetricasModel.getPerdidaPorOrden as jest.Mock).mockResolvedValue([4]);
+    const res = await service.obtenerPerdidasPorOrden();
+    expect(MetricasModel.getPerdidaPorOrden).toHaveBeenCalled();
+    expect(res).toEqual([4]);
+  });
+
+  it('obtenerProduccionCalidadMensual', async () => {
+    (MetricasModel.getProduccionPorCalidadMensual as jest.Mock).mockResolvedValue([5]);
+    const res = await service.obtenerProduccionCalidadMensual();
+    expect(MetricasModel.getProduccionPorCalidadMensual).toHaveBeenCalled();
+    expect(res).toEqual([5]);
+  });
+
+  it('obtenerPromedioPerdidaMensual', async () => {
+    (MetricasModel.getPromedioPerdidaPorMes as jest.Mock).mockResolvedValue([6]);
+    const res = await service.obtenerPromedioPerdidaMensual();
+    expect(MetricasModel.getPromedioPerdidaPorMes).toHaveBeenCalled();
+    expect(res).toEqual([6]);
+  });
+
+  it('obtenerKPIs', async () => {
+    (MetricasModel.getKPIs as jest.Mock).mockResolvedValue([7]);
+    const res = await service.obtenerKPIs();
+    expect(MetricasModel.getKPIs).toHaveBeenCalled();
+    expect(res).toEqual([7]);
+  });
+
+  it('obtenerDistribucionPedidos', async () => {
+    (MetricasModel.getDistribucionPedidosPorEstado as jest.Mock).mockResolvedValue([8]);
+    const res = await service.obtenerDistribucionPedidos();
+    expect(MetricasModel.getDistribucionPedidosPorEstado).toHaveBeenCalled();
+    expect(res).toEqual([8]);
+  });
+
+  it('obtenerTasaFinalizacion', async () => {
+    (MetricasModel.getTasaFinalizacionOrdenes as jest.Mock).mockResolvedValue([9]);
+    const res = await service.obtenerTasaFinalizacion();
+    expect(MetricasModel.getTasaFinalizacionOrdenes).toHaveBeenCalled();
+    expect(res).toEqual([9]);
+  });
+
+  it('obtenerPedidosDetallados', async () => {
+    (MetricasModel.getPedidosDetallados as jest.Mock).mockResolvedValue([10]);
+    const res = await service.obtenerPedidosDetallados();
+    expect(MetricasModel.getPedidosDetallados).toHaveBeenCalled();
+    expect(res).toEqual([10]);
+  });
+
+  it('obtenerOrdenesDetalladas', async () => {
+    (MetricasModel.getOrdenesProduccionDetalladas as jest.Mock).mockResolvedValue([11]);
+    const res = await service.obtenerOrdenesDetalladas();
+    expect(MetricasModel.getOrdenesProduccionDetalladas).toHaveBeenCalled();
+    expect(res).toEqual([11]);
+  });
+
+  it('obtenerPedidosClienteConstruccion', async () => {
+    (MetricasModel.getPedidosPorClienteConstruccion as jest.Mock).mockResolvedValue([12]);
+    const res = await service.obtenerPedidosClienteConstruccion();
+    expect(MetricasModel.getPedidosPorClienteConstruccion).toHaveBeenCalled();
+    expect(res).toEqual([12]);
+  });
+
+  it('obtenerOrdenesProduccionDetalladas', async () => {
+    (MetricasModel.getOrdenesProduccionDetalladas as jest.Mock).mockResolvedValue([13]);
+    const res = await service.obtenerOrdenesProduccionDetalladas();
+    expect(MetricasModel.getOrdenesProduccionDetalladas).toHaveBeenCalled();
+    expect(res).toEqual([13]);
+  });
+
+  it('obtenerMermasPorTipoLadrillo', async () => {
+    (MetricasModel.getMermasPorTipoLadrillo as jest.Mock).mockResolvedValue([14]);
+    const res = await service.obtenerMermasPorTipoLadrillo();
+    expect(MetricasModel.getMermasPorTipoLadrillo).toHaveBeenCalled();
+    expect(res).toEqual([14]);
+  });
+});

--- a/tests/ordenHornoService.test.ts
+++ b/tests/ordenHornoService.test.ts
@@ -1,0 +1,44 @@
+import * as OrdenModel from '../src/models/OrdenHorno';
+import {
+  obtenerOrdenes,
+  obtenerOrdenById,
+  registrarOrden,
+  finalizarOrden,
+  eliminarOrden
+} from '../src/services/ordenHornoService';
+
+jest.mock('../src/models/OrdenHorno');
+
+describe('ordenHornoService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('obtenerOrdenes debe invocar getAllOrdenes', async () => {
+    (OrdenModel.getAllOrdenes as jest.Mock).mockResolvedValue([]);
+    await obtenerOrdenes();
+    expect(OrdenModel.getAllOrdenes).toHaveBeenCalled();
+  });
+
+  it('obtenerOrdenById debe invocar getOrdenById', async () => {
+    (OrdenModel.getOrdenById as jest.Mock).mockResolvedValue({id:1});
+    const res = await obtenerOrdenById(1);
+    expect(OrdenModel.getOrdenById).toHaveBeenCalledWith(1);
+    expect(res).toEqual({id:1});
+  });
+
+  it('registrarOrden debe crear la orden y devolver id', async () => {
+    (OrdenModel.createOrden as jest.Mock).mockResolvedValue(2);
+    const id = await registrarOrden('prod','vagon','fecha',10,'Nuevo');
+    expect(OrdenModel.createOrden).toHaveBeenCalledWith('prod','vagon','fecha',10,'Nuevo');
+    expect(id).toBe(2);
+  });
+
+  it('finalizarOrden debe invocar updateOrdenFinal', async () => {
+    await finalizarOrden(1,'f',1,2,3,'Fin');
+    expect(OrdenModel.updateOrdenFinal).toHaveBeenCalledWith(1,'f',1,2,3,'Fin');
+  });
+
+  it('eliminarOrden debe invocar deleteOrden', async () => {
+    await eliminarOrden(3);
+    expect(OrdenModel.deleteOrden).toHaveBeenCalledWith(3);
+  });
+});

--- a/tests/pedidoService.test.ts
+++ b/tests/pedidoService.test.ts
@@ -1,0 +1,46 @@
+import * as PedidoModel from '../src/models/Pedido';
+import {
+  obtenerPedidos,
+  registrarPedido,
+  cambiarEstadoPedido,
+  eliminarPedido
+} from '../src/services/pedidoService';
+
+jest.mock('../src/models/Pedido');
+
+describe('pedidoService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('obtenerPedidos devuelve pedidos con detalles', async () => {
+    (PedidoModel.getAllPedidos as jest.Mock).mockResolvedValue([{ id_pedido: 1 }, { id_pedido: 2 }]);
+    (PedidoModel.getDetallesByPedido as jest.Mock).mockResolvedValue([]);
+
+    const res = await obtenerPedidos();
+
+    expect(PedidoModel.getAllPedidos).toHaveBeenCalled();
+    expect(PedidoModel.getDetallesByPedido).toHaveBeenCalledTimes(2);
+    expect(PedidoModel.getDetallesByPedido).toHaveBeenNthCalledWith(1, 1);
+    expect(PedidoModel.getDetallesByPedido).toHaveBeenNthCalledWith(2, 2);
+    expect(res).toEqual([{ id_pedido: 1, detalles: [] }, { id_pedido: 2, detalles: [] }]);
+  });
+
+  it('registrarPedido crea pedido y detalles', async () => {
+    (PedidoModel.createPedido as jest.Mock).mockResolvedValue(5);
+    const detalles = [{ id_producto: 1, cantidad_pedida: 2, fecha_estimada_entrega: 'f', precio_total: 10 }];
+    const id = await registrarPedido(3, detalles, 50, 5, 'Nuevo');
+
+    expect(PedidoModel.createPedido).toHaveBeenCalledWith(3, 50, 5, 'Nuevo');
+    expect(PedidoModel.createDetallePedido).toHaveBeenCalledWith(5, 1, 2, 'f', 10);
+    expect(id).toBe(5);
+  });
+
+  it('cambiarEstadoPedido actualiza el estado', async () => {
+    await cambiarEstadoPedido(2, 'Entregado');
+    expect(PedidoModel.updateEstadoPedido).toHaveBeenCalledWith(2, 'Entregado');
+  });
+
+  it('eliminarPedido elimina el pedido', async () => {
+    await eliminarPedido(4);
+    expect(PedidoModel.deletePedido).toHaveBeenCalledWith(4);
+  });
+});

--- a/tests/productoService.test.ts
+++ b/tests/productoService.test.ts
@@ -1,0 +1,44 @@
+import * as ProductoModel from '../src/models/Producto';
+import {
+  obtenerProductos,
+  obtenerProductoById,
+  registrarProducto,
+  editarProducto,
+  eliminarProducto
+} from '../src/services/productoService';
+
+jest.mock('../src/models/Producto');
+
+describe('productoService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('obtenerProductos debe invocar getAllProductos', async () => {
+    (ProductoModel.getAllProductos as jest.Mock).mockResolvedValue([]);
+    await obtenerProductos();
+    expect(ProductoModel.getAllProductos).toHaveBeenCalled();
+  });
+
+  it('obtenerProductoById debe invocar getProductoById', async () => {
+    (ProductoModel.getProductoById as jest.Mock).mockResolvedValue({id: 'p'});
+    const res = await obtenerProductoById('p');
+    expect(ProductoModel.getProductoById).toHaveBeenCalledWith('p');
+    expect(res).toEqual({id: 'p'});
+  });
+
+  it('registrarProducto debe crear y devolver datos', async () => {
+    (ProductoModel.createProducto as jest.Mock).mockResolvedValue(1);
+    const res = await registrarProducto('1','prod','tipo',5,10);
+    expect(ProductoModel.createProducto).toHaveBeenCalledWith('1','prod','tipo',5,10);
+    expect(res).toEqual({ id: 1, id_producto: '1', nombre_producto: 'prod', tipo: 'tipo', cantidad_stock: 5, precio_unitario: 10 });
+  });
+
+  it('editarProducto debe invocar updateProducto', async () => {
+    await editarProducto('1','prod','t',5,10);
+    expect(ProductoModel.updateProducto).toHaveBeenCalledWith('1','prod','t',5,10);
+  });
+
+  it('eliminarProducto debe invocar deleteProducto', async () => {
+    await eliminarProducto('1');
+    expect(ProductoModel.deleteProducto).toHaveBeenCalledWith('1');
+  });
+});

--- a/tests/reportesService.test.ts
+++ b/tests/reportesService.test.ts
@@ -1,0 +1,74 @@
+import * as ReporteModel from '../src/models/Reporte';
+import { generarHTMLPedidos, generarHTMLProduccion } from '../src/utils/pdfTemplate';
+import { generarReportePedidos, generarReporteProduccion } from '../src/services/reportesService';
+import puppeteer from 'puppeteer';
+import ExcelJS from 'exceljs';
+
+jest.mock('../src/models/Reporte');
+jest.mock('../src/utils/pdfTemplate');
+
+jest.mock('puppeteer', () => ({
+  launch: jest.fn().mockResolvedValue({
+    newPage: jest.fn().mockResolvedValue({
+      setContent: jest.fn(),
+      pdf: jest.fn().mockResolvedValue(Buffer.from('pdf'))
+    }),
+    close: jest.fn()
+  })
+}));
+
+class FakeSheet {
+  addRow = jest.fn();
+  getRow = jest.fn().mockReturnValue({ font: {} });
+}
+
+jest.mock('exceljs', () => {
+  return {
+    Workbook: jest.fn().mockImplementation(() => {
+      const sheet = new FakeSheet();
+      return {
+        addWorksheet: jest.fn(() => sheet),
+        worksheets: [sheet],
+        xlsx: {
+          writeBuffer: jest.fn().mockResolvedValue(Buffer.from('excel')),
+          load: jest.fn()
+        }
+      };
+    })
+  };
+});
+
+describe('reportesService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('generarReportePedidos en excel', async () => {
+    (ReporteModel.obtenerPedidosPorFechas as jest.Mock).mockResolvedValue([{ id_pedido:1, fecha_pedido:'2025-01-01', nombre_cliente:'c', estado_pedido:'e' }]);
+    const res = await generarReportePedidos('a','b','xlsx');
+    expect(ReporteModel.obtenerPedidosPorFechas).toHaveBeenCalledWith('a','b');
+    expect(res.nombreArchivo).toBe('reporte_pedidos.xlsx');
+    expect(res.buffer).toBeInstanceOf(Buffer);
+  });
+
+  it('generarReportePedidos en pdf', async () => {
+    (ReporteModel.obtenerPedidosPorFechas as jest.Mock).mockResolvedValue([]);
+    (generarHTMLPedidos as jest.Mock).mockReturnValue('<html>');
+    const res = await generarReportePedidos('a','b','pdf');
+    expect(generarHTMLPedidos).toHaveBeenCalled();
+    expect(res.nombreArchivo).toBe('reporte_pedidos.pdf');
+  });
+
+  it('generarReporteProduccion en pdf', async () => {
+    (ReporteModel.obtenerOrdenesProduccionPorFechas as jest.Mock).mockResolvedValue([{ nombre_producto:'tipo - prod', fecha_carga:'2025-01-01', fecha_descarga:'2025-01-02', estado_orden:'E' }]);
+    (generarHTMLProduccion as jest.Mock).mockReturnValue('<html>');
+    const res = await generarReporteProduccion('a','b','pdf');
+    expect(ReporteModel.obtenerOrdenesProduccionPorFechas).toHaveBeenCalledWith('a','b');
+    expect(generarHTMLProduccion).toHaveBeenCalled();
+    expect(res.nombreArchivo).toBe('reporte_produccion.pdf');
+  });
+
+  it('generarReporteProduccion en excel', async () => {
+    (ReporteModel.obtenerOrdenesProduccionPorFechas as jest.Mock).mockResolvedValue([{ nombre_producto:'tipo - prod', fecha_carga:'2025-01-01', fecha_descarga:'2025-01-02', estado_orden:'E', primera:1, segunda:2, tercera:3 }]);
+    const res = await generarReporteProduccion('a','b','xlsx');
+    expect(res.nombreArchivo).toBe('reporte_produccion.xlsx');
+  });
+});

--- a/tests/usuarioService.test.ts
+++ b/tests/usuarioService.test.ts
@@ -1,0 +1,54 @@
+import * as UsuarioModel from '../src/models/Usuario';
+import bcrypt from 'bcrypt';
+import { registrarUsuario } from '../src/services/usuarioService';
+
+jest.mock('../src/models/Usuario');
+jest.mock('bcrypt');
+
+describe('usuarioService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registrarUsuario debe hashear la contraseña y guardar el usuario', async () => {
+    (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+    (UsuarioModel.createUsuario as jest.Mock).mockResolvedValue(2);
+
+    const res = await registrarUsuario('nom', 'email', 'pass', 3);
+
+    expect(bcrypt.genSalt).toHaveBeenCalledWith(10);
+    expect(bcrypt.hash).toHaveBeenCalledWith('pass', 'salt');
+    expect(UsuarioModel.createUsuario).toHaveBeenCalledWith('nom', 'email', 'hashed', 3);
+    expect(res).toEqual({ id: 2, nombre: 'nom', email: 'email', rol: 3 });
+  });
+});
+
+import { obtenerUsuarios, obtenerUsuarioById, editarUsuario, eliminarUsuario } from '../src/services/usuarioService';
+
+describe('usuarioService additional functions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('obtenerUsuarios debe invocar getAllUsuarios', async () => {
+    (UsuarioModel.getAllUsuarios as jest.Mock).mockResolvedValue([]);
+    await obtenerUsuarios();
+    expect(UsuarioModel.getAllUsuarios).toHaveBeenCalled();
+  });
+
+  it('obtenerUsuarioById debe invocar getUsuarioById', async () => {
+    (UsuarioModel.getUsuarioById as jest.Mock).mockResolvedValue({id:1});
+    const res = await obtenerUsuarioById(1);
+    expect(UsuarioModel.getUsuarioById).toHaveBeenCalledWith(1);
+    expect(res).toEqual({id:1});
+  });
+
+  it('editarUsuario debe invocar updateUsuario', async () => {
+    await editarUsuario(1,'nom','email',2);
+    expect(UsuarioModel.updateUsuario).toHaveBeenCalledWith(1,'nom','email',2);
+  });
+
+  it('eliminarUsuario debe invocar deleteUsuario', async () => {
+    await eliminarUsuario(1);
+    expect(UsuarioModel.deleteUsuario).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- configure jest with ts-jest
- add unit tests for cliente and usuario services
- add tests for construccion, log, metricas, ordenHorno, pedido, producto and reportes services
- extend usuarioService tests for additional methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885a3b901a083239427d66380b0e829